### PR TITLE
BaseBackend is an Abstract class. It should not be used by anyone

### DIFF
--- a/generic_cache/backend.py
+++ b/generic_cache/backend.py
@@ -6,14 +6,19 @@ from datetime import datetime, timedelta
 
 
 class BaseBackend(object):
+    """
+    Abstract class that acts like every Cache Backend Interface. Extend it
+    to implement your own Cache Backend.
+    """
+
     def get(self, key):
-        return None
+        raise NotImplementedError("Subclasses should implement this method")
 
     def set(self, key, value, timeout=None):
-        return None
+        raise NotImplementedError("Subclasses should implement this method")
 
     def delete(self, key):
-        return None
+        raise NotImplementedError("Subclasses should implement this method")
 
 
 class InMemoryCache(BaseBackend):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -86,4 +86,11 @@ class TestGenericCache(CacheBaseTestCase):
         key = generic.get_key('type', 1, 2, kw='kwarg')
         self.assertEqual('MyCustomClass.type__1__2__kw_kwarg', key.key_str)
 
+    def test_raise_not_implemented_error(self):
+        """ Should not allow to use BaseBackend. It is an abstract class """
 
+        base = BaseBackend()
+
+        self.assertRaises(NotImplementedError, base.get, "key")
+        self.assertRaises(NotImplementedError, base.set, "key", "value")
+        self.assertRaises(NotImplementedError, base.delete, "key")


### PR DESCRIPTION
Add `raise NotImplementedError` to every method from BaseBackend to avoid anyone 
to use this class as the CacheBackend. Only child classes should implement its
methods. 

Tests are included.